### PR TITLE
fix: missing import when setting up approaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- A missing import was breaking the ability to edit skills on a sheet
+
 ## [v0.1.2](https://github.com/nivthefox/foundryvtt-fate-hybrid-skills/releases/tag/v0.1.2)
 ### Fixed
 - We probably shouldn't be force enabling debug hooks for all users, eh?

--- a/scripts/ApproachSetup.js
+++ b/scripts/ApproachSetup.js
@@ -1,4 +1,5 @@
-import {Approach} from './Models.js';
+import { Approach } from './Models.js';
+import { EditApproach } from './EditApproach.js';
 import * as Constants from './Constants.js';
 
 export class ApproachSetup extends FormApplication {

--- a/scripts/EditApproach.js
+++ b/scripts/EditApproach.js
@@ -1,4 +1,4 @@
-import {Approach} from './Models.js';
+import { Approach } from './Models.js';
 import * as Constants from './Constants.js';
 
 export class EditApproach extends FormApplication {

--- a/scripts/EditGMApproaches.js
+++ b/scripts/EditGMApproaches.js
@@ -1,5 +1,5 @@
 import * as Constants from './Constants.js';
-import {Approach} from './Models.js';
+import { Approach } from './Models.js';
 
 export class EditGMApproaches extends FormApplication {
     constructor(actor) {

--- a/scripts/EditPlayerApproaches.js
+++ b/scripts/EditPlayerApproaches.js
@@ -1,5 +1,5 @@
 import * as Constants from './Constants.js';
-import {EditGMApproaches} from './EditGMApproaches.js'
+import { EditGMApproaches } from './EditGMApproaches.js'
 
 export class EditPlayerApproaches extends FormApplication {
     constructor(...args) {

--- a/scripts/Hooks.js
+++ b/scripts/Hooks.js
@@ -1,4 +1,4 @@
-import {Actor} from './Actor.js';
+import { Actor } from './Actor.js';
 import * as Constants from './Constants.js';
 import * as Log from './Log.js';
 

--- a/scripts/Settings.js
+++ b/scripts/Settings.js
@@ -1,6 +1,6 @@
 import * as Constants from "./Constants.js";
 import * as Log from "./Log.js";
-import {ApproachSetup} from "./ApproachSetup.js";
+import { ApproachSetup } from "./ApproachSetup.js";
 
 export function registerSettings() {
     game.settings.register(Constants.MODULE_ID, "approachesLabel", {


### PR DESCRIPTION
ApproachSetup.js references EditApproach, but it was not being imported, which resulted in an uncaught reference error.

Resolves #7.