### PR TITLE
fix: re-render approach setup after approach edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Newly added approaches now update the list in the Approach Setup window.
+
 ## [v0.1.3](https://github.com/nivthefox/foundryvtt-fate-hybrid-skills/releases/tag/v0.1.2)
 ### Fixed
 - Approaches can now be exported (individually or all at once)

--- a/scripts/ApproachSetup.js
+++ b/scripts/ApproachSetup.js
@@ -86,10 +86,11 @@ export class ApproachSetup extends FormApplication {
     }
 
     async onAddButton(event, html) {
-        let edit = new EditApproach();
-        edit.render(true);
+        let editor = new EditApproach();
+        editor.render(true);
+        editor.setupWindow = this;
         try {
-            edit.bringToTop();
+            editor.bringToTop();
         } catch {
             // Do nothing.
         }
@@ -129,10 +130,11 @@ export class ApproachSetup extends FormApplication {
     async onEditButton(event, html) {
         // Lanch the EditApproach FormApplication.
         let approach = this.getSelectedApproach(html);
-        let edit = new EditApproach(approach);
-        edit.render(true);
+        let editor = new EditApproach(approach);
+        editor.render(true);
+        editor.setupWindow = this;
         try {
-            edit.bringToTop();
+            editor.bringToTop();
         } catch {
             // Do nothing.
         }

--- a/scripts/EditApproach.js
+++ b/scripts/EditApproach.js
@@ -124,5 +124,8 @@ export class EditApproach extends FormApplication {
             approaches[fcoConstants.tob64(approach.name)] = newApproach;
         }
         await game.settings.set(Constants.MODULE_ID, "approaches", approaches);
+        if (this.setupWindow != undefined) {
+            await this.setupWindow.render(false);
+        }
     }
 }


### PR DESCRIPTION
This will ensure that the approach list is always up-to-date with the correct approaches after a user edits an existing approach or adds a new approach to the game.

Resolves #11.